### PR TITLE
Guard thermal data download for undefined polymers

### DIFF
--- a/src/components/PHAPropertiesDashboard.jsx
+++ b/src/components/PHAPropertiesDashboard.jsx
@@ -7,8 +7,14 @@ const PHAPropertiesDashboard = () => {
   const [selectedPolymer, setSelectedPolymer] = useState('S1000P');
 
   const downloadThermalData = () => {
+    const data = thermalData[selectedPolymer];
+    if (!data) {
+      alert('No thermal data available for the selected polymer.');
+      return;
+    }
+
     const headers = ['temp', 'modulus', 'tanDelta'];
-    const rows = thermalData[selectedPolymer]
+    const rows = data
       .map(({ temp, modulus, tanDelta }) => `${temp},${modulus},${tanDelta}`)
       .join('\n');
     const csv = `${headers.join(',')}\n${rows}`;


### PR DESCRIPTION
## Summary
- Add guard in `downloadThermalData` to prevent CSV export when `thermalData` lacks the selected polymer.
- Notify users when no thermal data exists instead of building a CSV from undefined data.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a12b226ef4832d8d8e4c7758a148b2