### PR TITLE
Parse markdown bold in polymer specs

### DIFF
--- a/PHAPropertiesDashboard.jsx
+++ b/PHAPropertiesDashboard.jsx
@@ -6,6 +6,9 @@ import { LineChart, Line, BarChart, Bar, RadarChart, PolarGrid, PolarAngleAxis, 
 const PHAPropertiesDashboard = () => {
   const [selectedPolymer, setSelectedPolymer] = useState('S1000P');
 
+  const renderMarkdown = (text) =>
+    text.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>');
+
   const downloadThermalData = () => {
     const headers = ['temp', 'modulus', 'tanDelta'];
     const rows = thermalData[selectedPolymer]
@@ -159,7 +162,10 @@ const PHAPropertiesDashboard = () => {
             <CardContent>
               <div className="space-y-1 text-sm">
                 {spec.characteristics.map((char, idx) => (
-                  <div key={idx} dangerouslySetInnerHTML={{ __html: char }} />
+                  <div
+                    key={idx}
+                    dangerouslySetInnerHTML={{ __html: renderMarkdown(char) }}
+                  />
                 ))}
               </div>
             </CardContent>

--- a/src/components/PHAPropertiesDashboard.jsx
+++ b/src/components/PHAPropertiesDashboard.jsx
@@ -6,6 +6,9 @@ import { LineChart, Line, BarChart, Bar, RadarChart, PolarGrid, PolarAngleAxis, 
 const PHAPropertiesDashboard = () => {
   const [selectedPolymer, setSelectedPolymer] = useState('S1000P');
 
+  const renderMarkdown = (text) =>
+    text.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>');
+
   const downloadThermalData = () => {
     const headers = ['temp', 'modulus', 'tanDelta'];
     const rows = thermalData[selectedPolymer]
@@ -159,7 +162,10 @@ const PHAPropertiesDashboard = () => {
             <CardContent>
               <div className="space-y-1 text-sm">
                 {spec.characteristics.map((char, idx) => (
-                  <div key={idx} dangerouslySetInnerHTML={{ __html: char }} />
+                  <div
+                    key={idx}
+                    dangerouslySetInnerHTML={{ __html: renderMarkdown(char) }}
+                  />
                 ))}
               </div>
             </CardContent>


### PR DESCRIPTION
## Summary
- render **bold** markers in polymer specifications as `<strong>` tags
- ensure polymer characteristics are processed through a simple markdown helper before injecting HTML

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a12b24bdc4832da5b2718042510296