### PR TITLE
fix: update HTML validator config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,4 +10,4 @@
 [[plugins]]
   package = "netlify-plugin-html-validate"
   [plugins.inputs]
-    directory = "dist"
+    path = "dist"


### PR DESCRIPTION
## Summary
- fix Netlify plugin config to use `path` instead of unsupported `directory` input

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run build` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a13ff73538832db83f195d2fc72676