### PR TITLE
fix: update Netlify plugin configs

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -5,9 +5,9 @@
 [[plugins]]
   package = "netlify-plugin-bundle-env"
   [plugins.inputs]
-    source = "src"
+    directories = ["src"]
 
 [[plugins]]
   package = "netlify-plugin-html-validate"
   [plugins.inputs]
-    directory = "dist"
+    path = "dist"


### PR DESCRIPTION
## Summary
- fix Netlify plugin configs to use supported inputs for HTML validator and env bundling

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run build` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a13ff73538832db83f195d2fc72676